### PR TITLE
Add automatically generated change log file.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## [Unreleased](https://github.com/mattt/FormatterKit/tree/HEAD) (2015-03-02)
+## [Unreleased](https://github.com/mattt/FormatterKit/tree/HEAD)
 
 [Full Changelog](https://github.com/mattt/FormatterKit/compare/1.8.0...HEAD)
 
@@ -28,7 +28,7 @@
 
 **Merged pull requests:**
 
-- #147 Return presentDeicticExpression if past interval is less than least significant unit [\#148](https://github.com/mattt/FormatterKit/pull/148) ([krzyzanowskim](https://github.com/krzyzanowskim))
+- \#147 Return presentDeicticExpression if past interval is less than least significant unit [\#148](https://github.com/mattt/FormatterKit/pull/148) ([krzyzanowskim](https://github.com/krzyzanowskim))
 
 - Minutes abbreviated in french does not have an 's' :\) [\#146](https://github.com/mattt/FormatterKit/pull/146) ([hartbit](https://github.com/hartbit))
 
@@ -66,7 +66,7 @@
 
 - Cleans up the 'significantUnits' property. [\#141](https://github.com/mattt/FormatterKit/pull/141) ([sstigler](https://github.com/sstigler))
 
-- \[Issue #139\] Fix time interval calculation involving weeks. [\#140](https://github.com/mattt/FormatterKit/pull/140) ([scraton](https://github.com/scraton))
+- \[Issue \#139\] Fix time interval calculation involving weeks. [\#140](https://github.com/mattt/FormatterKit/pull/140) ([scraton](https://github.com/scraton))
 
 ## [1.7.1](https://github.com/mattt/FormatterKit/tree/1.7.1) (2014-10-05)
 
@@ -350,7 +350,7 @@
 
 - Add french localization [\#50](https://github.com/mattt/FormatterKit/pull/50) ([flambert](https://github.com/flambert))
 
-- Use NSLocalizedStringWithDefaultValue to fix issue #47 [\#48](https://github.com/mattt/FormatterKit/pull/48) ([flambert](https://github.com/flambert))
+- Use NSLocalizedStringWithDefaultValue to fix issue \#47 [\#48](https://github.com/mattt/FormatterKit/pull/48) ([flambert](https://github.com/flambert))
 
 - Deictic expression in Spanish lacked a character [\#44](https://github.com/mattt/FormatterKit/pull/44) ([alvaromb](https://github.com/alvaromb))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,471 @@
+# Change Log
+
+## [Unreleased](https://github.com/mattt/FormatterKit/tree/HEAD) (2015-03-02)
+
+[Full Changelog](https://github.com/mattt/FormatterKit/compare/1.8.0...HEAD)
+
+**Merged pull requests:**
+
+- Fix NSCalendarUnitCompareSignificance method [\#153](https://github.com/mattt/FormatterKit/pull/153) ([skywinder](https://github.com/skywinder))
+
+## [1.8.0](https://github.com/mattt/FormatterKit/tree/1.8.0) (2015-01-18)
+
+[Full Changelog](https://github.com/mattt/FormatterKit/compare/1.7.5...1.8.0)
+
+**Merged pull requests:**
+
+- Fixes creating curl from request with multiple cookies [\#150](https://github.com/mattt/FormatterKit/pull/150) ([podkovyrin](https://github.com/podkovyrin))
+
+- TTTUnitOfInformationFormatter on 32bit [\#149](https://github.com/mattt/FormatterKit/pull/149) ([hugocampossousa](https://github.com/hugocampossousa))
+
+## [1.7.5](https://github.com/mattt/FormatterKit/tree/1.7.5) (2014-12-08)
+
+[Full Changelog](https://github.com/mattt/FormatterKit/compare/1.7.4...1.7.5)
+
+**Closed issues:**
+
+- stringForTimeIntervalFromDate return nil [\#147](https://github.com/mattt/FormatterKit/issues/147)
+
+**Merged pull requests:**
+
+- #147 Return presentDeicticExpression if past interval is less than least significant unit [\#148](https://github.com/mattt/FormatterKit/pull/148) ([krzyzanowskim](https://github.com/krzyzanowskim))
+
+- Minutes abbreviated in french does not have an 's' :\) [\#146](https://github.com/mattt/FormatterKit/pull/146) ([hartbit](https://github.com/hartbit))
+
+## [1.7.4](https://github.com/mattt/FormatterKit/tree/1.7.4) (2014-11-24)
+
+[Full Changelog](https://github.com/mattt/FormatterKit/compare/1.7.3...1.7.4)
+
+**Closed issues:**
+
+- LocalizedStringKey "day" in TTTTimeIntervalFormatter used twice [\#144](https://github.com/mattt/FormatterKit/issues/144)
+
+**Merged pull requests:**
+
+- Updated Readme: Remove unused translations - prepare\_command instead of pre\_install [\#145](https://github.com/mattt/FormatterKit/pull/145) ([iv-mexx](https://github.com/iv-mexx))
+
+## [1.7.3](https://github.com/mattt/FormatterKit/tree/1.7.3) (2014-11-15)
+
+[Full Changelog](https://github.com/mattt/FormatterKit/compare/1.7.2...1.7.3)
+
+**Merged pull requests:**
+
+- Add Italian idiomatic time expressions [\#143](https://github.com/mattt/FormatterKit/pull/143) ([VivienCormier](https://github.com/VivienCormier))
+
+## [1.7.2](https://github.com/mattt/FormatterKit/tree/1.7.2) (2014-10-20)
+
+[Full Changelog](https://github.com/mattt/FormatterKit/compare/1.7.1...1.7.2)
+
+**Closed issues:**
+
+- version 1.7.1 breaks functionality in stringForTimeIntervalFromDate:toDate [\#139](https://github.com/mattt/FormatterKit/issues/139)
+
+- "yesterday" not working for .usesIdiomaticDeicticExpressions = YES on iOS 8 [\#138](https://github.com/mattt/FormatterKit/issues/138)
+
+**Merged pull requests:**
+
+- Cleans up the 'significantUnits' property. [\#141](https://github.com/mattt/FormatterKit/pull/141) ([sstigler](https://github.com/sstigler))
+
+- \[Issue #139\] Fix time interval calculation involving weeks. [\#140](https://github.com/mattt/FormatterKit/pull/140) ([scraton](https://github.com/scraton))
+
+## [1.7.1](https://github.com/mattt/FormatterKit/tree/1.7.1) (2014-10-05)
+
+[Full Changelog](https://github.com/mattt/FormatterKit/compare/1.7.0...1.7.1)
+
+**Closed issues:**
+
+- Seems that in podspec missing TTTNameFormatter [\#134](https://github.com/mattt/FormatterKit/issues/134)
+
+**Merged pull requests:**
+
+- Cleaning up minor compiler warnings: [\#137](https://github.com/mattt/FormatterKit/pull/137) ([hsoi](https://github.com/hsoi))
+
+- use NS\_ENUM for TTTArrayFormatter, TTTUnitOfInformationFormatter [\#136](https://github.com/mattt/FormatterKit/pull/136) ([adly-holler](https://github.com/adly-holler))
+
+- Updated german localization: Abbreviated Tag and Tagen [\#135](https://github.com/mattt/FormatterKit/pull/135) ([iv-mexx](https://github.com/iv-mexx))
+
+## [1.7.0](https://github.com/mattt/FormatterKit/tree/1.7.0) (2014-08-28)
+
+[Full Changelog](https://github.com/mattt/FormatterKit/compare/1.6.1...1.7.0)
+
+**Closed issues:**
+
+- Pod pre\_install locale script modifies other pods as well [\#131](https://github.com/mattt/FormatterKit/issues/131)
+
+**Merged pull requests:**
+
+- Updated German localization [\#133](https://github.com/mattt/FormatterKit/pull/133) ([plaetzchen](https://github.com/plaetzchen))
+
+- Prevent script from removing other Pod's folders [\#132](https://github.com/mattt/FormatterKit/pull/132) ([Zyphrax](https://github.com/Zyphrax))
+
+## [1.6.1](https://github.com/mattt/FormatterKit/tree/1.6.1) (2014-08-09)
+
+[Full Changelog](https://github.com/mattt/FormatterKit/compare/1.6.0...1.6.1)
+
+**Merged pull requests:**
+
+- Don't include the locale country if no country name is provided [\#130](https://github.com/mattt/FormatterKit/pull/130) ([tangphillip](https://github.com/tangphillip))
+
+- Add safety check when accessing NSLocaleCountryCode. [\#129](https://github.com/mattt/FormatterKit/pull/129) ([jurysch](https://github.com/jurysch))
+
+- Readme fixes [\#127](https://github.com/mattt/FormatterKit/pull/127) ([skirchmeier](https://github.com/skirchmeier))
+
+## [1.6.0](https://github.com/mattt/FormatterKit/tree/1.6.0) (2014-07-25)
+
+[Full Changelog](https://github.com/mattt/FormatterKit/compare/1.5.3...1.6.0)
+
+## [1.5.3](https://github.com/mattt/FormatterKit/tree/1.5.3) (2014-07-25)
+
+[Full Changelog](https://github.com/mattt/FormatterKit/compare/1.5.2...1.5.3)
+
+**Merged pull requests:**
+
+- \[Location Formatter\] Follow user preferences on metric defaults [\#126](https://github.com/mattt/FormatterKit/pull/126) ([kylef](https://github.com/kylef))
+
+- be consistent in using NSStringFromSelector [\#125](https://github.com/mattt/FormatterKit/pull/125) ([johngibb](https://github.com/johngibb))
+
+- Fixed bug in spanish translation logic and added polish translation. [\#124](https://github.com/mattt/FormatterKit/pull/124) ([verges](https://github.com/verges))
+
+## [1.5.2](https://github.com/mattt/FormatterKit/tree/1.5.2) (2014-07-08)
+
+[Full Changelog](https://github.com/mattt/FormatterKit/compare/1.5.1...1.5.2)
+
+**Merged pull requests:**
+
+- fixed a problem with TTTGetDegreesMinutesSecondsFromCoordinateDegrees fo... [\#123](https://github.com/mattt/FormatterKit/pull/123) ([ddwang](https://github.com/ddwang))
+
+- Fixing number of rows in example project [\#122](https://github.com/mattt/FormatterKit/pull/122) ([svobodamarek](https://github.com/svobodamarek))
+
+- Minor README correction  [\#121](https://github.com/mattt/FormatterKit/pull/121) ([RomainBoulay](https://github.com/RomainBoulay))
+
+## [1.5.1](https://github.com/mattt/FormatterKit/tree/1.5.1) (2014-06-16)
+
+[Full Changelog](https://github.com/mattt/FormatterKit/compare/1.5.0...1.5.1)
+
+**Closed issues:**
+
+- traditionally formatted latitude/longitude [\#118](https://github.com/mattt/FormatterKit/issues/118)
+
+**Merged pull requests:**
+
+- latitudeDirection should've been longitudeDirection here. [\#120](https://github.com/mattt/FormatterKit/pull/120) ([wooster](https://github.com/wooster))
+
+## [1.5.0](https://github.com/mattt/FormatterKit/tree/1.5.0) (2014-06-12)
+
+[Full Changelog](https://github.com/mattt/FormatterKit/compare/1.4.3...1.5.0)
+
+**Closed issues:**
+
+- Make localizedOrdinalIndicatorStringFromNumber public [\#115](https://github.com/mattt/FormatterKit/issues/115)
+
+**Merged pull requests:**
+
+- fixed warning with XCode 6.0 [\#119](https://github.com/mattt/FormatterKit/pull/119) ([marcopifferi](https://github.com/marcopifferi))
+
+- Sample script to remove unwanted locales in CocoaPods installation [\#117](https://github.com/mattt/FormatterKit/pull/117) ([miklselsoe](https://github.com/miklselsoe))
+
+- Fixed missing UIKit import [\#116](https://github.com/mattt/FormatterKit/pull/116) ([QuentinFiard](https://github.com/QuentinFiard))
+
+## [1.4.3](https://github.com/mattt/FormatterKit/tree/1.4.3) (2014-05-13)
+
+[Full Changelog](https://github.com/mattt/FormatterKit/compare/1.4.2...1.4.3)
+
+**Closed issues:**
+
+- Phone formatting support [\#114](https://github.com/mattt/FormatterKit/issues/114)
+
+- Inconsistency [\#112](https://github.com/mattt/FormatterKit/issues/112)
+
+- Hours, minutes and seconds formatter [\#111](https://github.com/mattt/FormatterKit/issues/111)
+
+- Error in Readme  [\#110](https://github.com/mattt/FormatterKit/issues/110)
+
+- TTTAddressFormatter & Cocoapods [\#108](https://github.com/mattt/FormatterKit/issues/108)
+
+- Update podspec to not use localizations [\#106](https://github.com/mattt/FormatterKit/issues/106)
+
+**Merged pull requests:**
+
+- Fix Japanese localization of minute \(was represented as second\) [\#113](https://github.com/mattt/FormatterKit/pull/113) ([akr4](https://github.com/akr4))
+
+- Add Chinese Traditional Localization [\#109](https://github.com/mattt/FormatterKit/pull/109) ([sodastsai](https://github.com/sodastsai))
+
+- Add fr Relative Date to TTTTimeIntervalFormatter [\#107](https://github.com/mattt/FormatterKit/pull/107) ([Bluezen](https://github.com/Bluezen))
+
+- Minor but repeated spelling error. [\#105](https://github.com/mattt/FormatterKit/pull/105) ([tewha](https://github.com/tewha))
+
+- Remove double semicolon. [\#104](https://github.com/mattt/FormatterKit/pull/104) ([tewha](https://github.com/tewha))
+
+## [1.4.2](https://github.com/mattt/FormatterKit/tree/1.4.2) (2014-03-24)
+
+[Full Changelog](https://github.com/mattt/FormatterKit/compare/1.4.1...1.4.2)
+
+**Closed issues:**
+
+- TTAddressFormatter from cocoapods [\#94](https://github.com/mattt/FormatterKit/issues/94)
+
+- Apps with FormatterKit are shown to support all languages FormatterKit supports in the App Store [\#88](https://github.com/mattt/FormatterKit/issues/88)
+
+**Merged pull requests:**
+
+- Adding "Suffix Expression Format String" key for Korean localization [\#103](https://github.com/mattt/FormatterKit/pull/103) ([bh2yoon](https://github.com/bh2yoon))
+
+- Adding "yesterday" and "tomorrow" localizations for Danish [\#102](https://github.com/mattt/FormatterKit/pull/102) ([runmad](https://github.com/runmad))
+
+- Add XCODE 5.1 compatibility [\#100](https://github.com/mattt/FormatterKit/pull/100) ([marcopifferi](https://github.com/marcopifferi))
+
+- Fixed Danish spelling of "second" and "seconds" [\#99](https://github.com/mattt/FormatterKit/pull/99) ([neoneye](https://github.com/neoneye))
+
+- Added Ukrainian localization [\#98](https://github.com/mattt/FormatterKit/pull/98) ([ikovalisko](https://github.com/ikovalisko))
+
+- add Chinese mainland localization [\#97](https://github.com/mattt/FormatterKit/pull/97) ([rickytan](https://github.com/rickytan))
+
+- iOS does not support language region settings [\#96](https://github.com/mattt/FormatterKit/pull/96) ([StephanieTa](https://github.com/StephanieTa))
+
+- Fix for warning generated by -Wunreachable-code. [\#95](https://github.com/mattt/FormatterKit/pull/95) ([tewha](https://github.com/tewha))
+
+- add Japanese support [\#93](https://github.com/mattt/FormatterKit/pull/93) ([moriturus](https://github.com/moriturus))
+
+- Add Czech localization [\#92](https://github.com/mattt/FormatterKit/pull/92) ([bobisjan](https://github.com/bobisjan))
+
+## [1.4.1](https://github.com/mattt/FormatterKit/tree/1.4.1) (2014-02-06)
+
+[Full Changelog](https://github.com/mattt/FormatterKit/compare/1.4.0...1.4.1)
+
+**Closed issues:**
+
+- Russian / plural forms support [\#90](https://github.com/mattt/FormatterKit/issues/90)
+
+- Lack of rounding in TTTTimeInterval gives inaccurate results [\#86](https://github.com/mattt/FormatterKit/issues/86)
+
+- Keys reused for localization [\#59](https://github.com/mattt/FormatterKit/issues/59)
+
+**Merged pull requests:**
+
+- Fixed Xcode 5.1 warnings for OS X target. [\#87](https://github.com/mattt/FormatterKit/pull/87) ([tomaz](https://github.com/tomaz))
+
+## [1.4.0](https://github.com/mattt/FormatterKit/tree/1.4.0) (2013-12-10)
+
+[Full Changelog](https://github.com/mattt/FormatterKit/compare/1.3.2...1.4.0)
+
+**Closed issues:**
+
+- Incorrect result for time format? [\#57](https://github.com/mattt/FormatterKit/issues/57)
+
+## [1.3.2](https://github.com/mattt/FormatterKit/tree/1.3.2) (2013-12-09)
+
+[Full Changelog](https://github.com/mattt/FormatterKit/compare/1.3.1...1.3.2)
+
+**Closed issues:**
+
+- TTTUnitOfInformationFormatter: Use doubleValue instead of \[number integerValue\] to calculate prefix when self.displaysInTermsOfBytes is YES? [\#82](https://github.com/mattt/FormatterKit/issues/82)
+
+- Lossy NSNumber [\#72](https://github.com/mattt/FormatterKit/issues/72)
+
+**Merged pull requests:**
+
+- Add Vietnamese localization [\#85](https://github.com/mattt/FormatterKit/pull/85) ([vinhnx](https://github.com/vinhnx))
+
+- Turn on and fix signedness conversion warning [\#84](https://github.com/mattt/FormatterKit/pull/84) ([sgleadow](https://github.com/sgleadow))
+
+- Added Turkish localization [\#81](https://github.com/mattt/FormatterKit/pull/81) ([safakge](https://github.com/safakge))
+
+## [1.3.1](https://github.com/mattt/FormatterKit/tree/1.3.1) (2013-11-15)
+
+[Full Changelog](https://github.com/mattt/FormatterKit/compare/1.3.0...1.3.1)
+
+**Closed issues:**
+
+- Undefined symbol with TTTAddressFormatter [\#46](https://github.com/mattt/FormatterKit/issues/46)
+
+- Yesterday not returned correctly for time difference less than 48 hours in TTTTimeIntervalFormatter [\#39](https://github.com/mattt/FormatterKit/issues/39)
+
+**Merged pull requests:**
+
+- Fix Dutch relative date strings [\#75](https://github.com/mattt/FormatterKit/pull/75) ([klaaspieter](https://github.com/klaaspieter))
+
+- Fix TTTTimeIntervalFormatter for German [\#73](https://github.com/mattt/FormatterKit/pull/73) ([mdornseif](https://github.com/mdornseif))
+
+- Fix typo [\#71](https://github.com/mattt/FormatterKit/pull/71) ([koenvanderdrift](https://github.com/koenvanderdrift))
+
+- Added missing implementation for colorFromCMYKString:. [\#70](https://github.com/mattt/FormatterKit/pull/70) ([Unkaputtbar](https://github.com/Unkaputtbar))
+
+## [1.3.0](https://github.com/mattt/FormatterKit/tree/1.3.0) (2013-09-27)
+
+[Full Changelog](https://github.com/mattt/FormatterKit/compare/1.2.1...1.3.0)
+
+**Closed issues:**
+
+- Setting locale for FormatterKit has no effect [\#69](https://github.com/mattt/FormatterKit/issues/69)
+
+**Merged pull requests:**
+
+- Korean localization [\#66](https://github.com/mattt/FormatterKit/pull/66) ([soleaf](https://github.com/soleaf))
+
+- Adding portuguese \(brazilian\) localization strings [\#65](https://github.com/mattt/FormatterKit/pull/65) ([marlonandrade](https://github.com/marlonandrade))
+
+- Fixed some Spanish issues [\#64](https://github.com/mattt/FormatterKit/pull/64) ([Lascorbe](https://github.com/Lascorbe))
+
+- Added Swedish localization [\#63](https://github.com/mattt/FormatterKit/pull/63) ([jenshandersson](https://github.com/jenshandersson))
+
+- Update FormatterKit.strings [\#62](https://github.com/mattt/FormatterKit/pull/62) ([thm76](https://github.com/thm76))
+
+## [1.2.1](https://github.com/mattt/FormatterKit/tree/1.2.1) (2013-08-13)
+
+[Full Changelog](https://github.com/mattt/FormatterKit/compare/1.2.0...1.2.1)
+
+**Closed issues:**
+
+- Incorrect version of podspec in Cocoapods repo [\#58](https://github.com/mattt/FormatterKit/issues/58)
+
+**Merged pull requests:**
+
+- added Greek localisation [\#61](https://github.com/mattt/FormatterKit/pull/61) ([qnoid](https://github.com/qnoid))
+
+- Add localization for Indonesian language \(id\) [\#60](https://github.com/mattt/FormatterKit/pull/60) ([nmutiara](https://github.com/nmutiara))
+
+- Fix else if in TTTTimeIntervalFormatter [\#56](https://github.com/mattt/FormatterKit/pull/56) ([JoshTheGeek](https://github.com/JoshTheGeek))
+
+## [1.2.0](https://github.com/mattt/FormatterKit/tree/1.2.0) (2013-07-09)
+
+[Full Changelog](https://github.com/mattt/FormatterKit/compare/1.1.2...1.2.0)
+
+**Closed issues:**
+
+- A percent symbol is missing in German [\#54](https://github.com/mattt/FormatterKit/issues/54)
+
+- The use of @"%@ %@" for dimensional, distance, speed and deictic expression breaks for french [\#47](https://github.com/mattt/FormatterKit/issues/47)
+
+- Please update the CocoaPods spec [\#45](https://github.com/mattt/FormatterKit/issues/45)
+
+**Merged pull requests:**
+
+- Add a percent symbol for German [\#55](https://github.com/mattt/FormatterKit/pull/55) ([BlackLee](https://github.com/BlackLee))
+
+- Missing code block in examples  [\#53](https://github.com/mattt/FormatterKit/pull/53) ([xHunter](https://github.com/xHunter))
+
+- Add localizations to sub spec instead of the spec [\#52](https://github.com/mattt/FormatterKit/pull/52) ([flambert](https://github.com/flambert))
+
+- TTTTimeIntervalFormatter: Specifying Precision [\#51](https://github.com/mattt/FormatterKit/pull/51) ([defragged](https://github.com/defragged))
+
+- Add french localization [\#50](https://github.com/mattt/FormatterKit/pull/50) ([flambert](https://github.com/flambert))
+
+- Use NSLocalizedStringWithDefaultValue to fix issue #47 [\#48](https://github.com/mattt/FormatterKit/pull/48) ([flambert](https://github.com/flambert))
+
+- Deictic expression in Spanish lacked a character [\#44](https://github.com/mattt/FormatterKit/pull/44) ([alvaromb](https://github.com/alvaromb))
+
+## [1.1.2](https://github.com/mattt/FormatterKit/tree/1.1.2) (2013-04-28)
+
+[Full Changelog](https://github.com/mattt/FormatterKit/compare/1.1.1...1.1.2)
+
+**Closed issues:**
+
+- Add single-letter abbreviations for TTTTimeIntervalFormatter [\#40](https://github.com/mattt/FormatterKit/issues/40)
+
+- stringForTimeIntervalFromDate performance issue [\#37](https://github.com/mattt/FormatterKit/issues/37)
+
+- TTTLocationFormatter should accept an NSLocale [\#36](https://github.com/mattt/FormatterKit/issues/36)
+
+- Project file is broken [\#32](https://github.com/mattt/FormatterKit/issues/32)
+
+- Zombie creation on LocalizeStringForKey [\#31](https://github.com/mattt/FormatterKit/issues/31)
+
+- TTTTimeIntervalFormatter uses NSLocalizedString instead of NSLocalizedStringFromTable [\#28](https://github.com/mattt/FormatterKit/issues/28)
+
+- Support for relative time of day [\#27](https://github.com/mattt/FormatterKit/issues/27)
+
+- Cocoapods 0.16 install generating incorrect OTHER\_LDFLAGS [\#25](https://github.com/mattt/FormatterKit/issues/25)
+
+- FormatterKit is generating Foundation.Framework errors [\#24](https://github.com/mattt/FormatterKit/issues/24)
+
+- enRelativeDateStringForComponents returns 'yesterday' incorrectly [\#22](https://github.com/mattt/FormatterKit/issues/22)
+
+- English ordinal for 213 is 'rd' [\#21](https://github.com/mattt/FormatterKit/issues/21)
+
+**Merged pull requests:**
+
+- Adding Danish localization [\#43](https://github.com/mattt/FormatterKit/pull/43) ([runmad](https://github.com/runmad))
+
+- Added Italian localization [\#42](https://github.com/mattt/FormatterKit/pull/42) ([gabro](https://github.com/gabro))
+
+- Fix crash when URL == nil [\#41](https://github.com/mattt/FormatterKit/pull/41) ([kolyuchiy](https://github.com/kolyuchiy))
+
+- Added Norwegian bokmål and nynorsk localization for TTTimeIntervalFormatter strings [\#38](https://github.com/mattt/FormatterKit/pull/38) ([bonkowski](https://github.com/bonkowski))
+
+- TTTUnitOfInformationFormatter: Support bigger numbers [\#34](https://github.com/mattt/FormatterKit/pull/34) ([brutella](https://github.com/brutella))
+
+- Handle Nil and Empty String Deictic Expressions [\#30](https://github.com/mattt/FormatterKit/pull/30) ([bcapps](https://github.com/bcapps))
+
+- Added Github's relevant .gitignores [\#29](https://github.com/mattt/FormatterKit/pull/29) ([mattbischoff](https://github.com/mattbischoff))
+
+## [1.1.1](https://github.com/mattt/FormatterKit/tree/1.1.1) (2012-11-24)
+
+[Full Changelog](https://github.com/mattt/FormatterKit/compare/1.1.0...1.1.1)
+
+**Merged pull requests:**
+
+- removing the "." from the short strings. Also remving the unicode char from the "Year Unit" description [\#23](https://github.com/mattt/FormatterKit/pull/23) ([kgn](https://github.com/kgn))
+
+- Added Spanish localization for TTTimeIntervalFormatter strings [\#20](https://github.com/mattt/FormatterKit/pull/20) ([alexito4](https://github.com/alexito4))
+
+- Added German localization for TTTimeIntervalFormatter strings [\#19](https://github.com/mattt/FormatterKit/pull/19) ([leberwurstsaft](https://github.com/leberwurstsaft))
+
+## [1.1.0](https://github.com/mattt/FormatterKit/tree/1.1.0) (2012-10-05)
+
+[Full Changelog](https://github.com/mattt/FormatterKit/compare/1.0.1...1.1.0)
+
+**Closed issues:**
+
+- TTTFormatter seems to be broken in ios6 [\#18](https://github.com/mattt/FormatterKit/issues/18)
+
+- Create "static iOS library" projects [\#16](https://github.com/mattt/FormatterKit/issues/16)
+
+- new tag and update podspec [\#15](https://github.com/mattt/FormatterKit/issues/15)
+
+**Merged pull requests:**
+
+- Silence compiler warning [\#17](https://github.com/mattt/FormatterKit/pull/17) ([ryanmaxwell](https://github.com/ryanmaxwell))
+
+## [1.0.1](https://github.com/mattt/FormatterKit/tree/1.0.1) (2012-09-17)
+
+[Full Changelog](https://github.com/mattt/FormatterKit/compare/1.0.0...1.0.1)
+
+**Closed issues:**
+
+- Using PodSpec subspecs lists source and header files twice [\#12](https://github.com/mattt/FormatterKit/issues/12)
+
+## [1.0.0](https://github.com/mattt/FormatterKit/tree/1.0.0) (2012-06-15)
+
+[Full Changelog](https://github.com/mattt/FormatterKit/compare/0.7.0...1.0.0)
+
+**Closed issues:**
+
+- TTTTimeIntervalFormatter \_approximateQualifierFormat is released twice [\#11](https://github.com/mattt/FormatterKit/issues/11)
+
+## [0.7.0](https://github.com/mattt/FormatterKit/tree/0.7.0) (2012-02-28)
+
+[Full Changelog](https://github.com/mattt/FormatterKit/compare/0.6.0...0.7.0)
+
+**Closed issues:**
+
+- Create a companion example project [\#2](https://github.com/mattt/FormatterKit/issues/2)
+
+- Package libraries into static .framework [\#1](https://github.com/mattt/FormatterKit/issues/1)
+
+**Merged pull requests:**
+
+- Fix leaks and analyzer warnings [\#8](https://github.com/mattt/FormatterKit/pull/8) ([zbowling](https://github.com/zbowling))
+
+- Addtitions to TTTURLRequestFormatter cURLCommandFromURLRequest [\#7](https://github.com/mattt/FormatterKit/pull/7) ([hezi](https://github.com/hezi))
+
+- Using unicode ordinal indicators for Italian, Portuguese, and Spanish [\#6](https://github.com/mattt/FormatterKit/pull/6) ([0xced](https://github.com/0xced))
+
+## [0.6.0](https://github.com/mattt/FormatterKit/tree/0.6.0) (2011-08-05)
+
+**Closed issues:**
+
+- Memory Leaks [\#3](https://github.com/mattt/FormatterKit/issues/3)
+
+
+
+\* *This Change Log was automatically generated by [github_changelog_generator](https://github.com/skywinder/Github-Changelog-Generator)*


### PR DESCRIPTION
Hi, mattt!
I create script, that generate change log file based on tags, issues and merged pull requests from GitHub issue tracker.
This [Change Log](https://github.com/skywinder/FormatterKit/blob/add-auto-changelog/CHANGELOG.md) was automatically generated by [github_changelog_generator](https://github.com/skywinder/Github-Changelog-Generator)
It helps to easily found what and when was fixed and implemented.
You can easily update this file by running gem: `github_changelog_generator mattt/FormatterKit`
I hope you find this commit as useful.
