### PR TITLE
Change degrees to an absolute value when converting to DMS format to …

### DIFF
--- a/FormatterKit/TTTLocationFormatter.m
+++ b/FormatterKit/TTTLocationFormatter.m
@@ -63,6 +63,8 @@ static inline void TTTGetDegreesMinutesSecondsFromCoordinateDegrees(CLLocationDe
     r = *m - floor(*m);
 
     *s = 60.0 * r;
+    
+    *d = fabs(*d);
 }
 
 static inline void TTTGetCardinalDirectionsFromCoordinate(CLLocationCoordinate2D coordinate, TTTLocationCardinalDirection *latitudeDirection, TTTLocationCardinalDirection *longitudeDirection) {


### PR DESCRIPTION
…avoid negative numbers. Magnitude in DMS is indicated by cardinal directions as opposed to sign.

Fixes #173 
