### PR TITLE
Corrects pluralization of German word for `years`

### DIFF
--- a/FormatterKit/FormatterKit.bundle/de.lproj/FormatterKit.strings
+++ b/FormatterKit/FormatterKit.bundle/de.lproj/FormatterKit.strings
@@ -168,7 +168,7 @@
 "year" = "Jahr";
 
 /* Year Unit (Plural) */
-"years" = "Jahre";
+"years" = "Jahren";
 
 /* Year Unit (Singular, Abbreviated) */
 "yr" = "J.";


### PR DESCRIPTION
The German word for "years" should be "Jahren" rather than "Jahre" in situations used by this library, i.e. in the [dative case](https://www.rocketlanguages.com/german/lessons/german-dative). This PR fixes the localization.

A similar (but correct) example is the localization for months: even though the normal pluralization is "Monate", "Monaten" is used because we have a dative situation.